### PR TITLE
fix: Handle None values in _create_progress_html to prevent TypeError

### DIFF
--- a/tests/unit/test_create_progress_html_fix.py
+++ b/tests/unit/test_create_progress_html_fix.py
@@ -1,0 +1,108 @@
+"""
+Test to verify that the _create_progress_html bug has been fixed.
+This tests that None values are handled gracefully.
+"""
+
+import time
+from yomitalk.app import PaperPodcastApp
+
+
+class TestCreateProgressHtmlFix:
+    """Test cases to verify the fix for _create_progress_html with None values."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.app = PaperPodcastApp()
+
+    def test_create_progress_html_with_none_total_parts_fixed(self):
+        """
+        Test that _create_progress_html handles None total_parts gracefully after the fix.
+        """
+        # This should no longer raise a TypeError
+        result = self.app._create_progress_html(
+            current_part=5,
+            total_parts=None,  # None should be handled gracefully
+            status_message="Test status",
+            is_completed=False,
+            start_time=time.time(),
+        )
+
+        # Verify we get a valid HTML string
+        assert isinstance(result, str)
+        assert len(result) > 0
+        assert "Test status" in result
+        assert "🎵" in result  # Should show the progress emoji
+
+    def test_create_progress_html_with_none_current_part(self):
+        """
+        Test that _create_progress_html handles None current_part gracefully.
+        """
+        result = self.app._create_progress_html(
+            current_part=None,  # None should be handled gracefully
+            total_parts=10,
+            status_message="Test with None current_part",
+            is_completed=False,
+            start_time=time.time(),
+        )
+
+        assert isinstance(result, str)
+        assert "Test with None current_part" in result
+
+    def test_create_progress_html_with_both_none(self):
+        """
+        Test that _create_progress_html handles both None values gracefully.
+        """
+        result = self.app._create_progress_html(current_part=None, total_parts=None, status_message="Both None", is_completed=False, start_time=time.time())
+
+        assert isinstance(result, str)
+        assert "Both None" in result
+
+    def test_create_progress_html_completed_with_none_values(self):
+        """
+        Test that completed status works even with None values.
+        """
+        result = self.app._create_progress_html(
+            current_part=None,
+            total_parts=None,
+            status_message="Completed test",
+            is_completed=True,  # Completed should bypass progress calculation
+            start_time=time.time(),
+        )
+
+        assert isinstance(result, str)
+        assert "Completed test" in result
+        assert "✅" in result  # Should show completion emoji
+
+    def test_normal_operation_still_works(self):
+        """
+        Test that normal operation with valid integers still works correctly.
+        """
+        result = self.app._create_progress_html(current_part=3, total_parts=10, status_message="Normal operation", is_completed=False, start_time=time.time())
+
+        assert isinstance(result, str)
+        assert "Normal operation" in result
+        # Should calculate 30% progress (but capped at 95%)
+        assert "🎵" in result
+
+    def test_progress_percentage_calculation_with_valid_values(self):
+        """
+        Test that progress percentage is calculated correctly with valid values.
+        """
+        result = self.app._create_progress_html(current_part=2, total_parts=4, status_message="Half done", is_completed=False)
+
+        # 2/4 = 50% progress
+        assert "50%" in result or "50 %" in result
+
+    def test_zero_division_protection(self):
+        """
+        Test that zero total_parts doesn't cause division by zero.
+        """
+        result = self.app._create_progress_html(
+            current_part=5,
+            total_parts=0,  # This should be handled without division error
+            status_message="Zero total",
+            is_completed=False,
+        )
+
+        assert isinstance(result, str)
+        assert "Zero total" in result

--- a/yomitalk/app.py
+++ b/yomitalk/app.py
@@ -1084,8 +1084,8 @@ class PaperPodcastApp:
 
     def _create_progress_html(
         self,
-        current_part: int,
-        total_parts: int,
+        current_part: Optional[int],
+        total_parts: Optional[int],
         status_message: str,
         is_completed: bool = False,
         start_time: Optional[float] = None,
@@ -1094,11 +1094,11 @@ class PaperPodcastApp:
         Create comprehensive progress display with progress bar, elapsed time, and estimated remaining time.
 
         Args:
-            current_part (int): Current part number
-            total_parts (int): Total number of parts
+            current_part (Optional[int]): Current part number (None treated as 0)
+            total_parts (Optional[int]): Total number of parts (None treated as 0)
             status_message (str): Status message to display
             is_completed (bool): Whether the generation is completed
-            start_time (float): Start time timestamp for calculating elapsed time
+            start_time (Optional[float]): Start time timestamp for calculating elapsed time
 
         Returns:
             str: HTML string for progress display
@@ -1109,7 +1109,10 @@ class PaperPodcastApp:
             progress_percent = 100
             emoji = "✅"
         else:
-            progress_percent = int(min(95, (current_part / total_parts) * 100) if total_parts > 0 else 0)
+            # Handle None values gracefully by treating them as 0
+            safe_current_part = current_part if current_part is not None else 0
+            safe_total_parts = total_parts if total_parts is not None else 0
+            progress_percent = int(min(95, (safe_current_part / safe_total_parts) * 100) if safe_total_parts > 0 else 0)
             emoji = "🎵"
 
         # 経過時間と推定残り時間を計算
@@ -1121,10 +1124,10 @@ class PaperPodcastApp:
 
             if is_completed:
                 time_info = f" | 完了時間: {elapsed_minutes:02d}:{elapsed_seconds:02d}"
-            elif current_part > 0 and not is_completed:
+            elif safe_current_part > 0 and not is_completed:
                 # 推定残り時間を計算（現在のペースに基づく）
-                avg_time_per_part = elapsed_time / current_part
-                remaining_parts = total_parts - current_part
+                avg_time_per_part = elapsed_time / safe_current_part
+                remaining_parts = safe_total_parts - safe_current_part
                 estimated_remaining = avg_time_per_part * remaining_parts
                 remaining_minutes = int(estimated_remaining // 60)
                 remaining_seconds = int(estimated_remaining % 60)


### PR DESCRIPTION
Fixed TypeError: '>' not supported between instances of 'NoneType' and 'int' that occurred when estimated_total_parts was None during session restoration.

Changes:
- Updated _create_progress_html to accept Optional[int] for parameters
- Added null safety checks converting None to 0 before arithmetic operations
- Fixed all usages of current_part and total_parts in time calculations
- Added comprehensive unit tests to verify None handling works correctly