### PR TITLE
refactor: remove redundant browser_state update methods

### DIFF
--- a/tests/unit/test_browser_state_management.py
+++ b/tests/unit/test_browser_state_management.py
@@ -46,8 +46,17 @@ class TestBrowserStateManagement:
         assert user_session.session_id == existing_session_id
         assert updated_browser_state["app_session_id"] == existing_session_id
 
-        # Browser state should remain unchanged
-        assert updated_browser_state == browser_state_with_session
+        # Browser state should be completed with UserSession defaults while preserving existing values
+        # Check that original values are preserved
+        assert updated_browser_state["ui_state"]["podcast_text"] == "Previous session content"
+        assert updated_browser_state["ui_state"]["terms_agreed"] is True
+        assert updated_browser_state["user_settings"]["current_api_type"] == "openai"
+        assert updated_browser_state["user_settings"]["character1"] == "Kyushu Sora"
+
+        # Check that missing fields are filled with defaults
+        assert "current_script" in updated_browser_state["audio_generation_state"]
+        assert "character2" in updated_browser_state["user_settings"]
+        assert "document_type" in updated_browser_state["user_settings"]
 
     def test_session_independence_from_gradio_hash(self):
         """Test that app session ID remains stable even when Gradio session hash changes."""

--- a/tests/unit/test_ui_initialization.py
+++ b/tests/unit/test_ui_initialization.py
@@ -212,62 +212,24 @@ class TestAudioStateUpdate:
         """Set up test fixtures."""
         self.app = PaperPodcastApp()
 
-    def test_update_browser_state_audio_status(self):
-        """Test updating audio status in BrowserState."""
-        from yomitalk.user_session import UserSession
-
-        user_session = UserSession()
+    def test_update_browser_state_ui_content(self):
+        """Test updating UI content in BrowserState."""
         browser_state = {
-            "app_session_id": user_session.session_id,
-            "audio_generation_state": {
-                "is_generating": True,
-                "progress": 0.5,
-                "status": "generating",
-                "current_script": "Test script",
-                "final_audio_path": None,
-                "streaming_parts": ["part1.wav"],
-                "generation_id": "gen123",
-            },
+            "app_session_id": "test-session",
+            "audio_generation_state": {},
             "user_settings": {},
-            "ui_state": {},
+            "ui_state": {"podcast_text": "old text", "terms_agreed": False},
         }
 
-        # Update the browser state audio status
-        updated_state = self.app.update_browser_state_audio_status(user_session, browser_state)
+        # Update UI content
+        updated_state = self.app.update_browser_state_ui_content(browser_state, "new podcast text", True)
 
-        # Verify the audio generation state is preserved/updated
-        audio_state = updated_state["audio_generation_state"]
-        assert "is_generating" in audio_state
-        assert "progress" in audio_state
-        assert "status" in audio_state
-        assert "current_script" in audio_state
+        # Verify UI state was updated
+        ui_state = updated_state["ui_state"]
+        assert ui_state["podcast_text"] == "new podcast text"
+        assert ui_state["terms_agreed"] is True
 
-    def test_update_browser_state_audio_status_with_none_session(self):
-        """Test audio status update handles None user session gracefully."""
-        browser_state = {"app_session_id": "test-uuid", "audio_generation_state": {}, "user_settings": {}, "ui_state": {}}
-
-        # Should handle None session gracefully - create dummy user session for testing
-        user_session = Mock()
-        user_session.session_id = "test-uuid"
-        user_session.is_audio_generating.return_value = False
-        user_session.get_audio_generation_progress.return_value = 0.0
-        user_session.get_audio_generation_status.return_value = {
-            "is_generating": False,
-            "progress": 0.0,
-            "status": "idle",
-            "current_script": "",
-            "final_audio_path": None,
-            "streaming_parts": [],
-            "generation_id": None,
-            "start_time": None,
-            "estimated_total_parts": 1,
-        }
-        user_session.get_current_script.return_value = ""
-        user_session.get_final_audio_path.return_value = None
-        user_session.get_streaming_audio_parts.return_value = []
-
-        updated_state = self.app.update_browser_state_audio_status(user_session, browser_state)
-
-        # Should return updated state with audio information
-        assert updated_state is not browser_state  # Different object
+        # Verify other sections are preserved
+        assert updated_state["app_session_id"] == "test-session"
         assert "audio_generation_state" in updated_state
+        assert "user_settings" in updated_state


### PR DESCRIPTION
borwser_stateの初期化周りをリファクタリング
browser_stateとuser_sessionの初期化時にどちらもデフォルト値を設定していたが、役割が重複しているため、browse_stateの値が不十分ならuser_sessionの初期値を採用するように変更。