### PR TITLE
feat: add pitch adjustment for 東北きりたん

### DIFF
--- a/yomitalk/common/character.py
+++ b/yomitalk/common/character.py
@@ -9,19 +9,20 @@ from enum import Enum
 class Character(Enum):
     """VOICEVOXキャラクター定義のEnum"""
 
-    ZUNDAMON = ("ずんだもん", 3, "0.vvm")  # ずんだもん (sweet)
-    SHIKOKU_METAN = ("四国めたん", 2, "0.vvm")  # 四国めたん (normal)
-    KYUSHU_SORA = ("九州そら", 16, "2.vvm")  # 九州そら (normal)
-    CHUGOKU_USAGI = ("中国うさぎ", 61, "3.vvm")  # 中国うさぎ (normal)
-    CHUBU_TSURUGI = ("中部つるぎ", 94, "18.vvm")  # 中部つるぎ (normal)
-    TOHOKU_ZUNKO = ("東北ずん子", 107, "21.vvm")  # 東北ずん子 (normal)
-    TOHOKU_KIRITAN = ("東北きりたん", 108, "21.vvm")  # 東北きりたん (normal)
-    TOHOKU_ITAKO = ("東北イタコ", 109, "21.vvm")  # 東北イタコ (normal)
+    ZUNDAMON = ("ずんだもん", 3, "0.vvm", 0.0)  # ずんだもん (sweet)
+    SHIKOKU_METAN = ("四国めたん", 2, "0.vvm", 0.0)  # 四国めたん (normal)
+    KYUSHU_SORA = ("九州そら", 16, "2.vvm", 0.0)  # 九州そら (normal)
+    CHUGOKU_USAGI = ("中国うさぎ", 61, "3.vvm", 0.0)  # 中国うさぎ (normal)
+    CHUBU_TSURUGI = ("中部つるぎ", 94, "18.vvm", 0.0)  # 中部つるぎ (normal)
+    TOHOKU_ZUNKO = ("東北ずん子", 107, "21.vvm", 0.0)  # 東北ずん子 (normal)
+    TOHOKU_KIRITAN = ("東北きりたん", 108, "21.vvm", 0.05)  # 東北きりたん (normal) - ピッチを5%上げる
+    TOHOKU_ITAKO = ("東北イタコ", 109, "21.vvm", 0.0)  # 東北イタコ (normal)
 
-    def __init__(self, display_name: str, style_id: int, model_file: str):
+    def __init__(self, display_name: str, style_id: int, model_file: str, pitch_scale: float):
         self.display_name = display_name
         self.style_id = style_id
         self.model_file = model_file
+        self.pitch_scale = pitch_scale
 
 
 DISPLAY_NAMES = [character.display_name for character in Character]

--- a/yomitalk/common/character.py
+++ b/yomitalk/common/character.py
@@ -27,6 +27,7 @@ class Character(Enum):
 
 DISPLAY_NAMES = [character.display_name for character in Character]
 STYLE_ID_BY_NAME = {character.display_name: character.style_id for character in Character}
+CHARACTER_BY_STYLE_ID = {character.style_id: character for character in Character}
 
 # キャラクターが必要とする音声モデルファイル（.vvm）の一覧
 REQUIRED_MODEL_FILES = sorted(set(character.model_file for character in Character))

--- a/yomitalk/components/audio_generator.py
+++ b/yomitalk/components/audio_generator.py
@@ -27,6 +27,7 @@ from yomitalk.common.character import (
     DISPLAY_NAMES,
     REQUIRED_MODEL_FILES,
     STYLE_ID_BY_NAME,
+    CHARACTER_BY_STYLE_ID,
     Character,
 )
 from yomitalk.utils.logger import logger
@@ -176,7 +177,8 @@ class VoicevoxCoreManager:
 
         try:
             # Get character-specific pitch scale
-            pitch_scale = self._get_pitch_scale_for_style_id(style_id)
+            character = CHARACTER_BY_STYLE_ID.get(style_id)
+            pitch_scale = character.pitch_scale if character else 0.0
 
             wav_data: bytes
             if pitch_scale != 0.0:
@@ -193,24 +195,6 @@ class VoicevoxCoreManager:
         except Exception as e:
             logger.error(f"Audio generation error: {e}")
             return b""
-
-    def _get_pitch_scale_for_style_id(self, style_id: int) -> float:
-        """
-        Get the pitch scale value for a given VOICEVOX style ID.
-
-        Args:
-            style_id: VOICEVOX style ID
-
-        Returns:
-            float: Pitch scale value (0.0 = no adjustment)
-        """
-        # Find character with matching style_id and return pitch_scale
-        for character in Character:
-            if character.style_id == style_id:
-                return character.pitch_scale
-
-        # Default: no pitch adjustment
-        return 0.0
 
     def is_available(self) -> bool:
         """Check if VOICEVOX Core is available and initialized."""


### PR DESCRIPTION
東北きりたんの声のピッチを5%上げる機能を実装

- Character enumにpitch_scaleパラメータを追加
- VoicevoxCoreManagerでキャラクター別ピッチ制御を実装  
- AudioQueryとsynthesisメソッドを使用した精密なピッチ制御
- 他のキャラクターへの影響なし