### PR TITLE
Replace pitch adjustment with speech speed adjustment

### DIFF
--- a/yomitalk/common/character.py
+++ b/yomitalk/common/character.py
@@ -9,20 +9,20 @@ from enum import Enum
 class Character(Enum):
     """VOICEVOXキャラクター定義のEnum"""
 
-    ZUNDAMON = ("ずんだもん", 3, "0.vvm", 0.0)  # ずんだもん (sweet)
-    SHIKOKU_METAN = ("四国めたん", 2, "0.vvm", 0.0)  # 四国めたん (normal)
-    KYUSHU_SORA = ("九州そら", 16, "2.vvm", 0.0)  # 九州そら (normal)
-    CHUGOKU_USAGI = ("中国うさぎ", 61, "3.vvm", 0.0)  # 中国うさぎ (normal)
-    CHUBU_TSURUGI = ("中部つるぎ", 94, "18.vvm", 0.0)  # 中部つるぎ (normal)
-    TOHOKU_ZUNKO = ("東北ずん子", 107, "21.vvm", 0.0)  # 東北ずん子 (normal)
-    TOHOKU_KIRITAN = ("東北きりたん", 108, "21.vvm", 0.05)  # 東北きりたん (normal) - ピッチを5%上げる
-    TOHOKU_ITAKO = ("東北イタコ", 109, "21.vvm", 0.0)  # 東北イタコ (normal)
+    ZUNDAMON = ("ずんだもん", 3, "0.vvm", 1.1)  # ずんだもん (sweet)
+    SHIKOKU_METAN = ("四国めたん", 2, "0.vvm", 1.1)  # 四国めたん (normal)
+    KYUSHU_SORA = ("九州そら", 16, "2.vvm", 1.1)  # 九州そら (normal)
+    CHUGOKU_USAGI = ("中国うさぎ", 61, "3.vvm", 1.1)  # 中国うさぎ (normal)
+    CHUBU_TSURUGI = ("中部つるぎ", 94, "18.vvm", 1.1)  # 中部つるぎ (normal)
+    TOHOKU_ZUNKO = ("東北ずん子", 107, "21.vvm", 1.1)  # 東北ずん子 (normal)
+    TOHOKU_KIRITAN = ("東北きりたん", 108, "21.vvm", 1.2)  # 東北きりたん (normal)
+    TOHOKU_ITAKO = ("東北イタコ", 109, "21.vvm", 1.1)  # 東北イタコ (normal)
 
-    def __init__(self, display_name: str, style_id: int, model_file: str, pitch_scale: float):
+    def __init__(self, display_name: str, style_id: int, model_file: str, speed_scale: float):
         self.display_name = display_name
         self.style_id = style_id
         self.model_file = model_file
-        self.pitch_scale = pitch_scale
+        self.speed_scale = speed_scale
 
 
 DISPLAY_NAMES = [character.display_name for character in Character]

--- a/yomitalk/components/audio_generator.py
+++ b/yomitalk/components/audio_generator.py
@@ -176,21 +176,21 @@ class VoicevoxCoreManager:
             return b""
 
         try:
-            # Get character-specific pitch scale
+            # Get character-specific speed scale
             character = CHARACTER_BY_STYLE_ID.get(style_id)
-            pitch_scale = character.pitch_scale if character else 0.0
+            speed_scale = character.speed_scale if character else 1.0
 
             wav_data: bytes
-            if pitch_scale != 0.0:
-                # Use create_audio_query + synthesis for pitch adjustment
+            if speed_scale != 1.0:
+                # Use create_audio_query + synthesis for speed adjustment
                 audio_query = self.core_synthesizer.create_audio_query(text, style_id)
-                audio_query.pitch_scale = pitch_scale
+                audio_query.speed_scale = speed_scale
                 wav_data = self.core_synthesizer.synthesis(audio_query, style_id)
             else:
-                # Use standard tts method for no pitch adjustment
+                # Use standard tts method for no speed adjustment
                 wav_data = self.core_synthesizer.tts(text, style_id)
 
-            logger.debug(f"Audio generation completed: {len(wav_data) // 1024} KB (pitch_scale: {pitch_scale})")
+            logger.debug(f"Audio generation completed: {len(wav_data) // 1024} KB (speed_scale: {speed_scale})")
             return wav_data
         except Exception as e:
             logger.error(f"Audio generation error: {e}")


### PR DESCRIPTION
## Changes
- Replace pitch_scale with speed_scale for character voice adjustment
- Change from pitch adjustment (音の高さ) to speech speed adjustment (話す速さ)
- Set all characters to 1.1x speed (10% faster than normal)
- Set TOHOKU_KIRITAN to 1.2x speed (20% faster than normal)
- Update audio_generator.py to use VOICEVOX speed_scale parameter

## Testing
- All 194 unit tests pass
- Character enum functionality verified
- Audio generation logic confirmed working