### PR TITLE
Add GPT-5 series models support

### DIFF
--- a/yomitalk/app.py
+++ b/yomitalk/app.py
@@ -1322,7 +1322,7 @@ class PaperPodcastApp:
                             with gr.Row():
                                 openai_max_tokens_slider = gr.Slider(
                                     minimum=100,
-                                    maximum=32768,
+                                    maximum=OpenAIModel.DEFAULT_MAX_TOKENS,
                                     value=OpenAIModel.DEFAULT_MAX_TOKENS,
                                     step=100,
                                     label="最大トークン数",

--- a/yomitalk/models/openai_model.py
+++ b/yomitalk/models/openai_model.py
@@ -20,10 +20,12 @@ class OpenAIModel:
         "gpt-4.1-nano",
         "gpt-4.1-mini",
         "gpt-4.1",
-        "o4-mini",
+        "gpt-5-nano",
+        "gpt-5-mini",
+        "gpt-5",
     ]
     DEFAULT_MODEL = "gpt-4.1-mini"
-    DEFAULT_MAX_TOKENS = 32768
+    DEFAULT_MAX_TOKENS = 32768  # limit for gpt-4.1 series
 
     def __init__(self) -> None:
         """Initialize OpenAIModel."""
@@ -74,7 +76,7 @@ class OpenAIModel:
             max_tokens_int = int(max_tokens)
             if max_tokens_int < 100:
                 return False
-            if max_tokens_int > 32768:
+            if max_tokens_int > self.DEFAULT_MAX_TOKENS:
                 return False
 
             self.max_tokens = max_tokens_int
@@ -135,8 +137,7 @@ class OpenAIModel:
             response = client.chat.completions.create(
                 model=self.model_name,
                 messages=[{"role": "user", "content": prompt}],
-                temperature=0.7,
-                max_tokens=self.max_tokens,
+                max_completion_tokens=self.max_tokens,
             )
 
             # Get response content


### PR DESCRIPTION
- Add gpt-5, gpt-5-mini, gpt-5-nano to available models
- Update OpenAI API usage with max_completion_tokens parameter
- Keep DEFAULT_MODEL as gpt-4.1-mini (better quality than gpt-5-mini for podcast generation)

Note: gpt-4.1-mini was set as the default because it was qualitatively better than gpt-5-mini. gpt-5-mini tends to include prompt instructions in dialogue output (e.g., "ですます調で整理します").